### PR TITLE
add drag and drop

### DIFF
--- a/public/board.js
+++ b/public/board.js
@@ -23,9 +23,10 @@ function handle_highlight(elem) {
     return function(ev) {
 
         //validates if square has a piece, and it is it's turn
-        if(ev.type === "dragstart" && (!elem || !elem.hasChildNodes() || 
-          !elem.children[0].classList.contains(to_move? "w" : "b"))){
-            return false
+        if(ev.type === "dragstart"){
+            if(!elem || !elem.hasChildNodes() || !elem.children[0].classList.contains(to_move? "w" : "b"))
+                return false
+            ev.dataTransfer.setDragImage(elem.children[0], 0, 0);
         }
 
         let moves = move(board, elem.id.charCodeAt(0) - 48, elem.id.charCodeAt(1) - 48, to_move)

--- a/public/board.js
+++ b/public/board.js
@@ -115,7 +115,7 @@ function handle_move(from_id, to_id) {
                 let passanted_pawn = document.getElementById(`3${en_passant_move}`)
 
                 while (passanted_pawn.firstChild) {
-                    onclickpassanted_pawn.removeChild(passanted_pawn.firstChild)
+                    passanted_pawn.removeChild(passanted_pawn.firstChild)
                 }
             } else {
                 let passanted_pawn = document.getElementById(`4${en_passant_move}`)

--- a/public/board.js
+++ b/public/board.js
@@ -5,7 +5,6 @@ let squares = document.getElementsByClassName('square')
 sync_board()
 
 let highlighted_squares = []
-let drag;
 
 //allow ondrop to fire
 document.addEventListener("dragover", (e) => e.preventDefault(), false)

--- a/public/board.js
+++ b/public/board.js
@@ -6,8 +6,17 @@ sync_board()
 
 let highlighted_squares = []
 
+//allow ondrop to fire
+document.addEventListener("dragover", (e) => e.preventDefault(), false)
+
+function piece_events(e){
+    e.onclick = e.ondrag = handle_highlight(e.id)
+    e.draggable = true
+    e.ondrop = null
+}
+
 for (let i = 0; i < squares.length; i++) {
-    squares[i].onclick = handle_highlight(squares[i].id)
+    piece_events(squares[i])
 }
 
 function handle_highlight(id) {
@@ -17,13 +26,14 @@ function handle_highlight(id) {
 
         for (let i = 0; i < highlighted_squares.length; i++) {
             highlighted_squares[i].classList.remove('highlight')
-            highlighted_squares[i].onclick = handle_highlight(highlighted_squares[i].id)
+            piece_events(highlighted_squares[i])
         }
 
         for (let i = 0; i < moves.length; i++) {
             let hlsquare = document.getElementById(`${moves[i][0]}${moves[i][1]}`)
 
             hlsquare.classList.add('highlight')
+            hlsquare.ondrop = handle_move(id, hlsquare.id)
             hlsquare.onclick = handle_move(id, hlsquare.id)
 
             highlighted_squares.push(hlsquare)
@@ -105,7 +115,7 @@ function handle_move(from_id, to_id) {
                 let passanted_pawn = document.getElementById(`3${en_passant_move}`)
 
                 while (passanted_pawn.firstChild) {
-                    passanted_pawn.removeChild(passanted_pawn.firstChild)
+                    onclickpassanted_pawn.removeChild(passanted_pawn.firstChild)
                 }
             } else {
                 let passanted_pawn = document.getElementById(`4${en_passant_move}`)
@@ -154,7 +164,8 @@ function handle_move(from_id, to_id) {
         to_element.append(piece)
 
         for (let i = 0; i < highlighted_squares.length; i++) {
-            highlighted_squares[i].onclick = handle_highlight(highlighted_squares[i].id)
+            //highlighted_squares[i].onclick = handle_highlight(highlighted_squares[i].id)
+            piece_events(highlighted_squares[i])
             highlighted_squares[i].classList.remove('highlight')
         }
 

--- a/public/board.js
+++ b/public/board.js
@@ -5,12 +5,13 @@ let squares = document.getElementsByClassName('square')
 sync_board()
 
 let highlighted_squares = []
+let drag;
 
 //allow ondrop to fire
 document.addEventListener("dragover", (e) => e.preventDefault(), false)
 
 function piece_events(e){
-    e.onclick = e.ondrag = handle_highlight(e.id)
+    e.onclick = e.ondragstart = handle_highlight(e)
     e.draggable = true
     e.ondrop = null
 }
@@ -19,11 +20,17 @@ for (let i = 0; i < squares.length; i++) {
     piece_events(squares[i])
 }
 
-function handle_highlight(id) {
-    return function() {
+function handle_highlight(elem) {
+    return function(ev) {
 
-        let moves = move(board, id.charCodeAt(0) - 48, id.charCodeAt(1) - 48, to_move)
+        //validates if square has a piece, and it is it's turn
+        if(ev.type === "dragstart" && (!elem || !elem.hasChildNodes() || 
+          !elem.children[0].classList.contains(to_move? "w" : "b"))){
+            return false
+        }
 
+        let moves = move(board, elem.id.charCodeAt(0) - 48, elem.id.charCodeAt(1) - 48, to_move)
+        
         for (let i = 0; i < highlighted_squares.length; i++) {
             highlighted_squares[i].classList.remove('highlight')
             piece_events(highlighted_squares[i])
@@ -33,8 +40,8 @@ function handle_highlight(id) {
             let hlsquare = document.getElementById(`${moves[i][0]}${moves[i][1]}`)
 
             hlsquare.classList.add('highlight')
-            hlsquare.ondrop = handle_move(id, hlsquare.id)
-            hlsquare.onclick = handle_move(id, hlsquare.id)
+            hlsquare.ondrop = handle_move(elem.id, hlsquare.id)
+            hlsquare.onclick = handle_move(elem.id, hlsquare.id)
 
             highlighted_squares.push(hlsquare)
         }


### PR DESCRIPTION
edit handle_highlight to allow the ondrop event.

~currently all board pieces can always be dragged, this does not break any moves though.~ fixed in https://github.com/IgrisBRC/chesslol/pull/6/commits/63265067a7f3659ebd2c6566deb17457c2f949dd